### PR TITLE
Use the newest Duo SDK

### DIFF
--- a/duo.nix
+++ b/duo.nix
@@ -3,8 +3,8 @@ let
   duo-buildroot-sdk = pkgs.fetchFromGitHub {
     owner = "milkv-duo";
     repo = "duo-buildroot-sdk";
-    rev = "bb11c7ccf5bfd90d9acf2dc2d753ab4dfec8341d";
-    hash = "sha256-FNSKTfen/JfWtb7Hng6JjjFbUxV9B4bNAriVL8206CY=";
+    rev = "0e0b8efb59bf8b9664353323abbfdd11751056a4"; # 2024-02-14
+    hash = "sha256-tG4nVVXh1Aq6qeoy+J1LfgsW+J1Yx6KxfB1gjxprlXU=";
   };
   version = "5.10.4";
   src = "${duo-buildroot-sdk}/linux_${lib.versions.majorMinor version}";
@@ -24,7 +24,6 @@ let
     CONFIG_BINFMT_ELF=y
     CONFIG_INOTIFY_USER=y
     CONFIG_CRYPTO_ZSTD=y
-    CONFIG_ZSMALLOC=y
     CONFIG_ZRAM=y
     CONFIG_MAGIC_SYSRQ=y
   '';
@@ -35,6 +34,7 @@ let
       --replace CONFIG_BLK_DEV_INITRD=y "" \
       --replace CONFIG_DEBUG_FS=y       "" \
       --replace CONFIG_VECTOR=y         "" \
+      --replace CONFIG_ZRAM=m           "" \
       --replace CONFIG_SIGNALFD=n       CONFIG_SIGNALFD=y \
       --replace CONFIG_TIMERFD=n        CONFIG_TIMERFD=y \
       --replace CONFIG_EPOLL=n          CONFIG_EPOLL=y
@@ -70,6 +70,9 @@ in
   };
 
   boot.kernelPackages = pkgs.linuxPackagesFor kernel;
+
+  # neither boot.kernelParams nor boot.consoleLogLevel have any effect here
+  # due to the way the duo images work
   boot.kernelParams = [ "console=ttyS0,115200" "earlycon=sbi" "riscv.fwsz=0x80000" ];
   boot.consoleLogLevel = 9;
 


### PR DESCRIPTION
This PR just bumps the Duo buildroot SDK version to the latest.

I tested it on a Milk V Duo, here is the console log:

```
Boot from SD ...
switch to partitions #0, OK
mmc0 is current device
17356524 bytes read in 772 ms (21.4 MiB/s)
## Loading kernel from FIT Image at 81400000 ...
   Using 'config-cv1800b_milkv_duo_sd' configuration
   Trying 'kernel-1' kernel subimage
   Verifying Hash Integrity ... crc32+ OK
## Loading ramdisk from FIT Image at 81400000 ...
   Using 'config-cv1800b_milkv_duo_sd' configuration
   Trying 'ramdisk-1' ramdisk subimage
   Verifying Hash Integrity ... OK
## Loading fdt from FIT Image at 81400000 ...
   Using 'config-cv1800b_milkv_duo_sd' configuration
   Trying 'fdt-1' fdt subimage
   Verifying Hash Integrity ... sha256+ OK
   Booting using the fdt blob at 0x824883d8
   Loading Kernel Image
   Decompressing 7879680 bytes used 10ms
   Loading Ramdisk to 82db4000, end 836b8574 ... OK
   Loading Device Tree to 0000000082dac000, end 0000000082db3db9 ... OK

Starting kernel ...

[    0.000000] Linux version 5.10.4 (nixbld@localhost) (riscv64-unknown-linux-gnu-gcc (GCC) 13.2.0, GNU ld (GNU Binutils) 2.40) #1-NixOS PREEMPT Tue Jan 1 00:00:00 UTC 1980
[    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')
[    0.000000] printk: bootconsole [sbi0] enabled
[    0.000000] efi: UEFI not found.
[    0.000000] Initial ramdisk at: 0x(____ptrval____) (9457664 bytes)
[    0.000000] Ion: Ion memory setup at 0x0000000083f40000 size 0 MiB
[    0.000000] OF: reserved mem: initialized node ion, compatible id ion-region
[    0.000000] Zone ranges:
[    0.000000]   DMA32    [mem 0x0000000080000000-0x0000000083f3ffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000080000000-0x0000000083f3ffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000080000000-0x0000000083f3ffff]
[    0.000000] On node 0 totalpages: 16192
[    0.000000]   DMA32 zone: 222 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 16192 pages, LIFO batch:3
[    0.000000] SBI specification v0.3 detected
[    0.000000] SBI implementation ID=0x1 Version=0x9
[    0.000000] SBI v0.2 TIME extension detected
[    0.000000] SBI v0.2 IPI extension detected
[    0.000000] SBI v0.2 RFENCE extension detected
[    0.000000] riscv: ISA extensions acdfimsuv
[    0.000000] riscv: ELF capabilities acdfimv
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 15970
[    0.000000] Kernel command line: init=/nix/store/wykg9q6wlmns2cawghsw0v9pa1v78p77-nixos-system-nixos-24.05.20240206.74f7f37/init console=ttyS0,115200 earlycon=sbi riscv.fwsz=0x80000 logle
vel=9
[    0.000000] Dentry cache hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.000000] Inode-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.000000] Sorting __ex_table...
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 45832K/64768K available (4134K kernel code, 491K rwdata, 2855K rodata, 152K init, 212K bss, 18936K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu:     RCU event tracing is enabled.
[    0.000000]  Trampoline variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] riscv-intc: 64 local interrupts mapped
[    0.000000] plic: interrupt-controller@70000000: mapped 101 interrupts with 1 handlers for 2 contexts.
[    0.000000] random: get_random_bytes called from start_kernel+0x2f4/0x448 with crng_init=0
[    0.000000] riscv_timer_init_dt: Registering clocksource cpuid [0] hartid [0]
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0x5c40939b5, max_idle_ns: 440795202646 ns
[    0.000008] sched_clock: 64 bits at 25MHz, resolution 40ns, wraps every 4398046511100ns
[    0.008428] Calibrating delay loop (skipped), value calculated using timer frequency.. 50.00 BogoMIPS (lpj=100000)
[    0.019127] pid_max: default: 4096 minimum: 301
[    0.024033] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.031450] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.041243] ASID allocator initialised with 65536 entries
[    0.046966] rcu: Hierarchical SRCU implementation.
[    0.052361] EFI services will not be available.
[    0.057457] devtmpfs: initialized
[    0.065762] early_time_log: do_initcalls: 4417681us
[    0.071353] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.081410] futex hash table entries: 16 (order: -4, 384 bytes, linear)
[    0.088434] pinctrl core: initialized pinctrl subsystem
[    0.094380] NET: Registered protocol family 16
[    0.099398] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.106730] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.115603] thermal_sys: Registered thermal governor 'step_wise'
[    0.130866] OF: /gpio@03020000/gpio-controller@0: could not find phandle
[    0.144093] OF: /gpio@03021000/gpio-controller@1: could not find phandle
[    0.151073] OF: /gpio@03022000/gpio-controller@2: could not find phandle
[    0.158064] OF: /gpio@03023000/gpio-controller@3: could not find phandle
[    0.165049] OF: /gpio@05021000/gpio-controller@4: could not find phandle
[    0.174000] clk reset: nr_reset=64 resource_size=8
[    0.179585] get audio clk=24576000
[    0.183123] cvitek-i2s-subsys 4108000.i2s_subsys: Set clk_sdma_aud0~3 to 24576000
[    0.205312] dw_dmac 4330000.dma: CVITEK DMA Controller, 8 channels, probe done!
[    0.213847] SCSI subsystem initialized
[    0.218176] usbcore: registered new interface driver usbfs
[    0.223949] usbcore: registered new interface driver hub
[    0.229529] usbcore: registered new device driver usb
[    0.238165] Ion: ion_parse_dt_heap_common: id 0 type 2 name carveout align 1000
[    0.246038] Ion: rmem_ion_device_init: heap carveout base 0x0000000083f40000 size 0x0000000000000000 dev (____ptrval____)
[    0.257315] ion_carveout_heap_create, size=0x0
[    0.262104] cvi_get_rtos_ion_size, rtos ion_size get:0x0
[    0.267718] platform carveout: [ion] add heap id 0, type 2, base 0x83f40000, size 0x0
[    0.276170] Advanced Linux Sound Architecture Driver Initialized.
[    0.283716] clocksource: Switched to clocksource riscv_clocksource
[    0.292244] NET: Registered protocol family 2
[    0.297880] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.306595] TCP established hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.314390] TCP bind hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.321659] TCP: Hash tables configured (established 512 bind 512)
[    0.328255] UDP hash table entries: 128 (order: 0, 4096 bytes, linear)
[    0.335020] UDP-Lite hash table entries: 128 (order: 0, 4096 bytes, linear)
[    0.342462] NET: Registered protocol family 1
[    0.347624] RPC: Registered named UNIX socket transport module.
[    0.353765] RPC: Registered udp transport module.
[    0.358625] RPC: Registered tcp transport module.
[    0.363547] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.372019] Unpacking initramfs...
[    1.456382] Freeing initrd memory: 9232K
[    1.461159] Initialise system trusted keyrings
[    1.465996] workingset: timestamp_bits=62 max_order=14 bucket_order=0
[    1.479346] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    1.486353] jffs2: version 2.2. (NAND) © 2001-2006 Red Hat, Inc.
[    1.493726] NET: Registered protocol family 38
[    1.498308] Key type asymmetric registered
[    1.502574] Asymmetric key parser 'x509' registered
[    1.513641] cvi_rtos_cmdqu_init
[    1.517125] cvi_rtos_cmdqu_probe start ---
[    1.521320] name=1900000.rtos_cmdqu
[    1.525189] res-reg: start: 0x1900000, end: 0x1900fff, virt-addr(ffffffd004549000).
[    1.533094] RTOS_CMDQU_INIT
[    1.536005] mbox_reg=(____ptrval____)
[    1.539852] mbox_done_reg=(____ptrval____)
[    1.544152] mailbox_context=(____ptrval____)
[    1.548670] cvi_rtos_cmdqu_probe DONE
[    1.552636] cvi_rtos_cmdqu_init done
[    1.556302] [cvi_spinlock_init] success
[    1.560601] Serial: 8250/16550 driver, 5 ports, IRQ sharing disabled
[    1.569251] printk: console [ttyS0] disabled
[    1.573779] 4140000.serial: ttyS0 at MMIO 0x4140000 (irq = 15, base_baud = 1562500) is a 16550A
[    1.582903] printk: console [ttyS0] enabled
[    1.582903] printk: console [ttyS0] enabled
[    1.591506] printk: bootconsole [sbi0] disabled
[    1.591506] printk: bootconsole [sbi0] disabled
[    1.601765] 41c0000.serial: ttyS4 at MMIO 0x41c0000 (irq = 16, base_baud = 1562500) is a 16550A
[    1.612619] zram: Added device: zram0
[    1.619053] cvi-spif 10000000.cvi-spif: unrecognized JEDEC id bytes: 00 00 00 00 00 00
[    1.627289] cvi-spif 10000000.cvi-spif: device scan failed
[    1.632989] cvi-spif 10000000.cvi-spif: unable to setup flash chip
[    1.645899] libphy: Fixed MDIO Bus: probed
[    1.650755] bm-dwmac 4070000.ethernet: IRQ eth_wake_irq not found
[    1.657119] bm-dwmac 4070000.ethernet: IRQ eth_lpi not found
[    1.663103] bm-dwmac 4070000.ethernet: Hash table entries set to unexpected value 0
[    1.671171] bm-dwmac 4070000.ethernet: no reset control found
[    1.677419] bm-dwmac 4070000.ethernet: User ID: 0x10, Synopsys ID: 0x37
[    1.684337] bm-dwmac 4070000.ethernet:       DWMAC1000
[    1.689238] bm-dwmac 4070000.ethernet: DMA HW capability register supported
[    1.696461] bm-dwmac 4070000.ethernet: RX Checksum Offload Engine supported
[    1.703683] bm-dwmac 4070000.ethernet: COE Type 2
[    1.708572] bm-dwmac 4070000.ethernet: TX Checksum insertion supported
[    1.715345] bm-dwmac 4070000.ethernet: Normal descriptors
[    1.720951] bm-dwmac 4070000.ethernet: Ring mode enabled
[    1.726473] bm-dwmac 4070000.ethernet: Enable RX Mitigation via HW Watchdog Timer
[    1.734235] bm-dwmac 4070000.ethernet: device MAC address 4a:f8:47:6a:fa:b5
[    1.768494] libphy: stmmac: probed
[    1.773530] bm-dwmac 4070000.ethernet: Cannot get clk_500m_eth!
[    1.779902] bm-dwmac 4070000.ethernet: Cannot get gate_clk_axi4!
[    1.787320] dwc2 4340000.usb: axi clk installed
[    1.792130] dwc2 4340000.usb: apb clk installed
[    1.796867] dwc2 4340000.usb: 125m clk installed
[    1.801678] dwc2 4340000.usb: 33k clk installed
[    1.806398] dwc2 4340000.usb: 12m clk installed
[    1.811203] dwc2 4340000.usb: EPs: 8, dedicated fifos, 3072 entries in SPRAM
[    1.819090] dwc2 4340000.usb: DWC OTG Controller
[    1.823982] dwc2 4340000.usb: new USB bus registered, assigned bus number 1
[    1.831260] dwc2 4340000.usb: irq 37, io mem 0x04340000
[    1.837620] hub 1-0:1.0: USB hub found
[    1.841645] hub 1-0:1.0: 1 port detected
[    1.847043] usbcore: registered new interface driver usb-storage
[    1.853744] i2c /dev entries driver
[    1.859550] sdhci: Secure Digital Host Controller Interface driver
[    1.866001] sdhci: Copyright(c) Pierre Ossman
[    1.870532] sdhci-pltfm: SDHCI platform and OF driver helper
[    1.876676] cvi:sdhci_cvi_probe
[    1.927735] mmc0: SDHCI controller on 4310000.cv-sd [4310000.cv-sd] using ADMA 64-bit
[    1.935910] cvi_proc_init cvi_host 0x(____ptrval____)
[    1.941864] usbcore: registered new interface driver usbhid
[    1.951731] usbhid: USB HID core driver
[    1.957615] cvitek-i2s 4100000.i2s: cvi_i2s_probe
[    1.968035] cvitek-i2s 4120000.i2s: cvi_i2s_probe
[    1.973492] cvitek-i2s 4130000.i2s: cvi_i2s_probe
[    1.979359] cviteka-adc sound_adc: cviteka_adc_probe, dev name=sound_adc
[    1.991781] cviteka-adc sound_adc: cviteka_adc_probe start devm_snd_soc_register_card
[    2.000396] cvitekaadc 300a100.adc: cvitekaadc_probe
[    2.006523] cviteka-dac sound_dac: cviteka_dac_probe, dev name=sound_dac
[    2.014000] cvitekadac 300a000.dac: cvitekadac_probe
[    2.019465] cvitekadac_probe gpio_is_valid mute_pin_l
[    2.026108] NET: Registered protocol family 10
[    2.032704] Segment Routing with IPv6
[    2.036799] NET: Registered protocol family 17
[    2.041725] Loading compiled-in X.509 certificates
[    2.075804] mmc0: new high speed SDHC card at address aaaa
[    2.085800] cviteka-adc sound_adc: cviteka_adc_probe, dev name=sound_adc
[    2.093307] mmcblk0: mmc0:aaaa SD32G 29.7 GiB 
[    2.097989] cviteka-adc sound_adc: cviteka_adc_probe start devm_snd_soc_register_card
[    2.109077]  mmcblk0: p1 p2
[    2.118086] cviteka-dac sound_dac: cviteka_dac_probe, dev name=sound_dac
[    2.131243] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[    2.142255] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
[    2.149449] cfg80211: failed to load regulatory.db
[    2.154653] ALSA device list:
[    2.158197] dw-apb-uart 4140000.serial: forbid DMA for kernel console
[    2.165161] Freeing unused kernel memory: 152K
[    2.169830] Kernel memory protection not selected by kernel config.
[    2.176375] Run /init as init process
[    2.180228]   with arguments:
[    2.183301]     /init
[    2.185705]   with environment:
[    2.189007]     HOME=/
[    2.191450]     TERM=linux
[    2.194313] early_time_log: run_init_process: 6546236us

<<< NixOS Stage 1 >>>

running udev...
[    2.408586] stage-1-init: [Thu Jan  1 00:00:02 UTC 1970] running udev...
Starting systemd-udevd version 255.2
[    2.536720] stage-1-init: [Thu Jan  1 00:00:02 UTC 1970] Starting systemd-udevd version 255.2
[    3.389848] bm-dwmac 4070000.ethernet end0: renamed from eth0
kbd_mode: KDSKBMODE: Inappropriate ioctl for device
Gloadkmap: can't open console
starting device mapper and LVM..[    3.778596] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] kbd_mode: KDSKBMODE: Inappropriate ioctl for device
.
[    3.816669] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] loadkmap: can't open console
[    3.827462] random: lvm: uninitialized urandom read (4 bytes read)
[    3.848200] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] starting device mapper and LVM...
  Failed to set up async io, using sync io.
[    3.880715] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] Failed to set up async io, using sync io.
checking /dev/disk/by-label/NIXOS_SD...
fsck (busybox 1.36.1)
[fsck.ext4 (1) -- /mnt-root/][    4.018111] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] checking /dev/disk/by-label/NIXOS_SD...
 fsck.ext4 -a /dev/disk/by-label/NIXOS_SD
NIXOS_SD: clean, 47605/59904 fil[    4.050442] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] fsck (busybox 1.36.1)
es, 223285/232023 blocks
[    4.067629] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] [fsck.ext4 (1) -- /mnt-root/] fsck.ext4 -a /dev/disk/by-label/NIXOS_SD
[    4.087892] stage-1-init: [Thu Jan  1 00:00:03 UTC 1970] NIXOS_SD: clean, 47605/59904 files, 223285/232023 blocks
mounting /dev/disk/by-label/NIXOS_SD on /...
[    4.123918] stage-1-init: [Thu Jan  1 00:00:04 UTC 1970] mounting /dev/disk/by-label/NIXOS_SD on /...
[    4.136472] EXT4-fs (mmcblk0p2): mounted filesystem with ordered data mode. Opts: (null)
[    4.152152] EXT4-fs (mmcblk0p2): re-mounted. Opts: (null)

<<< NixOS Stage 2 >>>

[    4.867953] random: fast init done
[    4.912807] EXT4-fs (mmcblk0p2): re-mounted. Opts: (null)
[    4.921240] booting system configuration /nix/store/wykg9q6wlmns2cawghsw0v9pa1v78p77-nixos-system-nixos-24.05.20240206.74f7f37
running activation script...[    5.195651] stage-2-init: running activation script...

[    5.371908] random: perl: uninitialized urandom read (4 bytes read)
[    5.435908] random: perl: uninitialized urandom read (4 bytes read)
[    7.262639] random: perl: uninitialized urandom read (4 bytes read)
setting up /etc...[    7.365887] stage-2-init: setting up /etc...

[    7.391520] random: perl: uninitialized urandom read (4 bytes read)
[    7.398978] random: perl: uninitialized urandom read (4 bytes read)
++ /nix/store/i3fzyrygyl2an6r5kk[    9.022359] stage-2-init: ++ /nix/store/i3fzyrygyl2an6r5kkjnkjx3d3fynwhr-util-linux-riscv64-unknown-linux-gnu-2.39.3-bin/bin/findmnt -n -o SOURCE /
jnkjx3d3fynwhr-util-linux-riscv64-unknown-linux-gnu-2.39.3-bin/bin/findmnt -n -o SOURCE /
+ rootPart=/dev/disk/by-label/NI[    9.053169] stage-2-init: + rootPart=/dev/disk/by-label/NIXOS_SD
XOS_SD
++ lsblk -npo PKNAME /de[    9.061800] stage-2-init: ++ lsblk -npo PKNAME /dev/disk/by-label/NIXOS_SD
v/disk/by-label/NIXOS_SD
+ bootDevice=/dev/mmcblk0[    9.094543] stage-2-init: + bootDevice=/dev/mmcblk0

++ lsblk -npo MAJ:MIN /dev/disk/[    9.106173] stage-2-init: ++ lsblk -npo MAJ:MIN /dev/disk/by-label/NIXOS_SD
by-label/NIXOS_SD
++ /nix/store/sqaqqbznigm68ankng8inf48pq158hwi-gawk-riscv64-unknown-linux-gnu-5.2.2/bin/awk -F: '{print $2}'
[    9.132437] stage-2-init: ++ /nix/store/sqaqqbznigm68ankng8inf48pq158hwi-gawk-riscv64-unknown-linux-gnu-5.2.2/bin/awk -F: '{print $2}'
+ partNum='2  '[    9.172155] stage-2-init: + partNum='2  '

+ sfdisk -N2 --no-reread /dev/mmcblk0
+ echo ,+,
[    9.182349] stage-2-init: + sfdisk -N2 --no-reread /dev/mmcblk0
[    9.190790] stage-2-init: + echo ,+,
Disk /dev/mmcblk0: 29.72 GiB, 31[    9.651221] stage-2-init: Disk /dev/mmcblk0: 29.72 GiB, 31914983424 bytes, 62333952 sectors
914983424 bytes, 62333952 sector[    9.663349] stage-2-init: Units: sectors of 1 * 512 = 512 bytes
s
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/p[    9.674667] stage-2-init: Sector size (logical/physical): 512 bytes / 512 bytes
[    9.686784] stage-2-init: I/O size (minimum/optimal): 512 bytes / 512 bytes

I/O size (minimum/optimal): 512[    9.695454] stage-2-init: Disklabel type: dos
 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x2178[    9.704777] stage-2-init: Disk identifier: 0x2178694e
694e

Old situation:

Device[    9.714176] stage-2-init: Old situation:
         Boot  Start     End Sec[    9.721376] stage-2-init: Device         Boot  Start     End Sectors   Size Id Type
tors   Size Id Type
/dev/mmcblk0p1       16384  147455  131072 [    9.733447] stage-2-init: /dev/mmcblk0p1       16384  147455  131072    64M  b W95 FAT32
   64M  b W95 FAT32
/dev/mmcblk[    9.747022] stage-2-init: /dev/mmcblk0p2 *    147456 2003639 1856184 906.3M 83 Linux
0p2 *    147456 2003639 1856184 [    9.756878] stage-2-init: /dev/mmcblk0p2:
906.3M 83 Linux

/dev/mmcblk0p[    9.763891] stage-2-init: New situation:
2: 
New situation:
Disklabel t[    9.770810] stage-2-init: Disklabel type: dos
ype: dos
Disk identifier: 0x217[    9.778430] stage-2-init: Disk identifier: 0x2178694e
8694e

Device         Boot  St[    9.786651] stage-2-init: Device         Boot  Start      End  Sectors  Size Id Type
art      End  Sectors  Size Id T[    9.797592] stage-2-init: /dev/mmcblk0p1       16384   147455   131072   64M  b W95 FAT32
ype
/dev/mmcblk0p1       16384 [    9.808666] stage-2-init: /dev/mmcblk0p2 *    147456 62333951 62186496 29.7G 83 Linux
  147455   131072   64M  b W95 F[    9.820853] stage-2-init: The partition table has been altered.
AT32
/dev/mmcblk0p2 *    147456[    9.828772] stage-2-init: Calling ioctl() to re-read partition table.
 62333951 62186496 29.7G 83 Linux

The partition table has bee[    9.840473] stage-2-init: Re-reading the partition table failed.: Device or resource busy
n altered.
Calling ioctl() to re-read partition table.
Re-read[    9.854037] stage-2-init: The kernel still uses the old table. The new table will be used at the next reboot or after you run partprobe(8) or partx(8).
ing the partition table failed.:[    9.872228] stage-2-init: Syncing disks.
 Device or resource busy
The ke[    9.880291] stage-2-init: + /nix/store/alj8qdbbzp12q50q50pqny3pyy2qhysc-parted-riscv64-unknown-linux-gnu-3.6/bin/partprobe
rnel still uses the old table. The new table will be used at the next reboot or after you run partprobe(8) or partx(8).
Syncing disks.
+ /nix/store/alj8qdbbzp12q50q50pqny3pyy2qhysc-parted-riscv64-unknown-linux-gnu-3.6/bin/partprobe
+ /nix/store/5s7ivyzsnl90hr64zs6[   10.005402] stage-2-init: + /nix/store/5s7ivyzsnl90hr64zs60r803mvvf0vns-e2fsprogs-riscv64-unknown-linux-gnu-1.47.0-bin/bin/resize2fs /dev/disk/by-label/NIX
OS_SD
0r803mvvf0vns-e2fsprogs-riscv64-unknown-linux-gnu-1.47.0-bin/bin/resize2fs /dev/disk/by-label/NIXOS_SD
resize2fs 1.47.0 (5-Feb-2023)[   10.068726] stage-2-init: resize2fs 1.47.0 (5-Feb-2023)

[   10.083222] EXT4-fs (mmcblk0p2): resizing filesystem from 232023 to 7773312 blocks
[   10.617535] EXT4-fs (mmcblk0p2): resized filesystem to 7773312
Filesystem at /dev/disk/by-label[   10.778199] stage-2-init: Filesystem at /dev/disk/by-label/NIXOS_SD is mounted on /; on-line resizing required
/NIXOS_SD is mounted on /; on-line resizing required
old_desc_b[   10.795380] stage-2-init: old_desc_blocks = 1, new_desc_blocks = 4
locks = 1, new_desc_blocks = 4
[   10.804827] stage-2-init: The filesystem on /dev/disk/by-label/NIXOS_SD is now 7773312 (4k) blocks long.
The filesystem on /dev/disk/by-label/NIXOS_SD is now 7773312 (4k[   10.818446] stage-2-init: + /nix/store/2br2xn03cdklbzsyv3j139l1wfngj9sq-nix-riscv64-unknown-linux-gnu-2.18.1/bin/nix-store 
--load-db
) blocks long.

+ /nix/store/2br2xn03cdklbzsyv3j139l1wfngj9sq-nix-riscv64-unknown-linux-gnu-2.18.1/bin/nix-store --load-db
[   17.955797] random: crng init done
+ touch /etc/NIXOS[   19.132436] stage-2-init: + touch /etc/NIXOS

+ /nix/store/2br2xn03cdklbzsyv3j[   19.183140] stage-2-init: + /nix/store/2br2xn03cdklbzsyv3j139l1wfngj9sq-nix-riscv64-unknown-linux-gnu-2.18.1/bin/nix-env -p /nix/var/nix/profiles/system --
set /run/current-system
139l1wfngj9sq-nix-riscv64-unknown-linux-gnu-2.18.1/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+ rm -f /nix-path-registration[   20.179069] stage-2-init: + rm -f /nix-path-registration

starting systemd...
[   20.632096] systemd[1]: System time before build time, advancing clock.
[   20.834905] systemd[1]: systemd 255.2 running in system mode (+PAM +AUDIT -SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +I
PTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD +BPF_FRAMEWORK -XKBCOMMON +UTMP -SYSVINIT default-hierarchy=unified)
[   20.867956] systemd[1]: Detected architecture riscv64.

Welcome to NixOS 24.05 (Uakari)!

[   20.901517] systemd[1]: Hostname set to <nixos>.
[   20.912760] systemd[1]: Initializing machine ID from random generator.
[   21.011605] systemd[1]: bpf-lsm: BPF LSM hook not enabled in the kernel, BPF LSM not supported
[   23.346090] systemd[1]: Queued start job for default target Multi-User System.
[   23.387838] systemd[1]: init.scope: unit configures an IP firewall, but the local system does not support BPF/cgroup firewalling.
[   23.400026] systemd[1]: init.scope: (This warning is only shown for the first unit using IP firewalling.)
[   23.416485] systemd[1]: Created slice Slice /system/getty.
[  OK  ] Created slice Slice /system/getty.
[   23.437840] systemd[1]: Created slice Slice /system/modprobe.
[  OK  ] Created slice Slice /system/modprobe.
[   23.461885] systemd[1]: Created slice Slice /system/serial-getty.
[  OK  ] Created slice Slice /system/serial-getty.
[   23.485950] systemd[1]: Created slice Slice /system/systemd-zram-setup.
[  OK  ] Created slice Slice /system/systemd-zram-setup.
[   23.513557] systemd[1]: Created slice User and Session Slice.
[  OK  ] Created slice User and Session Slice.
[   23.536707] systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
[  OK  ] Started Dispatch Password Requests to Console Directory Watch.
[   23.564637] systemd[1]: Started Forward Password Requests to Wall Directory Watch.
[  OK  ] Started Forward Password Requests to Wall Directory Watch.
[   23.592276] systemd[1]: Expecting device /dev/ttyS0...
         Expecting device /dev/ttyS0...
[   23.612003] systemd[1]: Expecting device /dev/zram0...
         Expecting device /dev/zram0...
[   23.632048] systemd[1]: Reached target Local Encrypted Volumes.
[  OK  ] Reached target Local Encrypted Volumes.
[   23.652211] systemd[1]: Reached target Containers.
[  OK  ] Reached target Containers.
[   23.672260] systemd[1]: Reached target Path Units.
[  OK  ] Reached target Path Units.
[   23.692176] systemd[1]: Reached target Remote File Systems.
[  OK  ] Reached target Remote File Systems.
[   23.712146] systemd[1]: Reached target Slice Units.
[  OK  ] Reached target Slice Units.
[   23.755941] systemd[1]: Listening on Process Core Dump Socket.
[  OK  ] Listening on Process Core Dump Socket.
[   23.777732] systemd[1]: Listening on Journal Socket (/dev/log).
[  OK  ] Listening on Journal Socket (/dev/log).
[   23.801789] systemd[1]: Listening on Journal Socket.
[  OK  ] Listening on Journal Socket.
[   23.824312] systemd[1]: Userspace Out-Of-Memory (OOM) Killer Socket was skipped because of an unmet condition check (ConditionPathExists=/proc/pressure/memory).
[   23.841681] systemd[1]: Listening on udev Control Socket.
[  OK  ] Listening on udev Control Socket.
[   23.865720] systemd[1]: Listening on udev Kernel Socket.
[  OK  ] Listening on udev Kernel Socket.
[   23.889212] systemd[1]: Huge Pages File System was skipped because of an unmet condition check (ConditionPathExists=/sys/kernel/mm/hugepages).
[   23.910697] systemd[1]: Mounting POSIX Message Queue File System...
         Mounting POSIX Message Queue File System...
[   23.937627] systemd[1]: Mounting Kernel Debug File System...
         Mounting Kernel Debug File System...
[   23.960495] systemd[1]: Create List of Static Device Nodes was skipped because of an unmet condition check (ConditionFileNotEmpty=/run/booted-system/kernel-modules/lib/modules/5.10.4/modu
les.devname).
[   23.988069] systemd[1]: Starting Load Kernel Module configfs...
         Starting Load Kernel Module configfs...
[   24.017956] systemd[1]: Starting Load Kernel Module drm...
         Starting Load Kernel Module drm...
[   24.085487] systemd[1]: Starting Load Kernel Module efi_pstore...
         Starting Load Kernel Module efi_pstore...
[   24.157453] systemd[1]: Starting Load Kernel Module fuse...
         Starting Load Kernel Module fuse...
[   24.244558] systemd[1]: Starting mount-pstore.service...
         Starting mount-pstore.service...
[   24.341133] systemd[1]: Starting Create SUID/SGID Wrappers...
         Starting Create SUID/SGID Wrappers...
[   24.428441] systemd[1]: File System Check on Root Device was skipped because of an unmet condition check (ConditionPathIsReadWrite=!/).
[   24.601172] systemd[1]: Starting Journal Service...
         Starting Journal Service...
[   24.680713] systemd[1]: Starting Load Kernel Modules...
         Starting Load Kernel Modules...
[   24.757611] systemd[1]: Starting Remount Root and Kernel File Systems...
         Starting Remount Root and Kernel File Systems...
[   24.831631] systemd[1]: Starting Create Static Device Nodes in /dev gracefully...
         Starting Create Static Device Nodes in /dev gracefully...
[   24.914699] systemd[1]: Starting Coldplug All udev Devices...
         Starting Coldplug All udev Devices...
[   25.104178] systemd[1]: Mounted POSIX Message Queue File System.
[  OK  [   25.150580] systemd[1]: Mounted Kernel Debug File System.
] Mounted POSIX Message Queue File System.
[  OK  ] Mounted Kernel Debug File System.
[   25.227167] systemd[1]: modprobe@configfs.service: Deactivated successfully.
[   25.300126] systemd[1]: Finished Load Kernel Module configfs.
[  OK  ] Finished Load Kernel Module configfs.
[   25.402948] systemd[1]: modprobe@drm.service: Deactivated successfully.
[   25.457663] systemd[1]: Finished Load Kernel Module drm.
[   25.499326] EXT4-fs (mmcblk0p2): re-mounted. Opts: (null)
[  OK  ] Finished Load Kernel Module drm.
[   25.531248] systemd[1]: modprobe@efi_pstore.service: Deactivated successfully.
[   25.576033] systemd[1]: Finished Load Kernel Module efi_pstore.
[  OK  ] Finished Load Kernel Module efi_pstore.
[   25.679081] systemd[1]: modprobe@fuse.service: Deactivated successfully.
[   25.735568] systemd[1]: Finished Load Kernel Module fuse.
[  OK  ] Finished Load Kernel Module fuse.
[   25.787279] systemd[1]: mount-pstore.service: Skipped due to 'exec-condition'.
[   25.832025] systemd[1]: Condition check resulted in mount-pstore.service being skipped.
[   25.879986] systemd[1]: Finished Load Kernel Modules.
[  OK  ] Finished Load Kernel Modules.
[   25.914323] systemd[1]: Finished Remount Root and Kernel File Systems.
[  OK  ] Finished Remount Root and Kernel File Systems.
[   25.966314] systemd[1]: Finished Create Static Device Nodes in /dev gracefully.
[  OK  ] Finished Create Static Device Nodes in /dev gracefully.
[   26.032177] systemd[1]: FUSE Control File System was skipped because of an unmet condition check (ConditionPathExists=/sys/fs/fuse/connections).
[   26.108881] systemd[1]: Mounting Kernel Configuration File System...
         Mounting Kernel Configuration File System...
[   26.156285] systemd[1]: Platform Persistent Storage Archival was skipped because of an unmet condition check (ConditionDirectoryNotEmpty=/sys/fs/pstore).
[   26.235027] systemd-journald[308]: Collecting audit messages is disabled.
[   26.245478] systemd[1]: Starting Load/Save OS Random Seed...
         Starting Load/Save OS Random Seed...
[   26.321454] systemd[1]: Starting Apply Kernel Variables...
         Starting Apply Kernel Variables...
[   26.405204] systemd[1]: Starting Create Static Device Nodes in /dev...
         Starting Create Static Device Nodes in /dev...
[   26.555343] systemd[1]: Mounted Kernel Configuration File System.
[  OK  ] Mounted Kernel Configuration File System.
[   26.966116] systemd[1]: Finished Load/Save OS Random Seed.
[  OK  ] Finished Load/Save OS Random Seed.
[   27.152822] systemd[1]: Finished Apply Kernel Variables.
[  OK  ] Finished Apply Kernel Variables.
[   27.241951] systemd[1]: Finished Create Static Device Nodes in /dev.
[  OK  ] Finished Create Static Device Nodes in /dev.
[   27.288795] systemd[1]: Reached target Preparation for Local File Systems.
[  OK  ] Reached target Preparation for Local File Systems.
[   27.332233] systemd[1]: Reached target Local File Systems.
[  OK  ] Reached target Local File Systems.
[   27.385252] systemd[1]: Starting Rule-based Manager for Device Events and Files...
         Starting Rule-based Manager for Device Events and Files...
[   27.681579] systemd[1]: Started Journal Service.
[  OK  ] Started Journal Service.
         Starting Flush Journal to Persistent Storage...
[   28.031035] (md-udevd)[363]: systemd-udevd.service: ProtectHostname=yes is configured, but the kernel does not support UTS namespaces, ignoring namespace setup.
[   28.256637] systemd-journald[308]: Received client request to flush runtime journal.
[  OK  ] Finished Create SUID/SGID Wrappers.
[  OK  ] Finished Flush Journal to Persistent Storage.
         Starting Create Volatile Files and Directories...
[  OK  ] Finished Coldplug All udev Devices.
[  OK  ] Started Rule-based Manager for Device Events and Files.
[  OK  ] Found device /dev/zram0.
         Starting Create swap on /dev/zram0...
[  OK  ] Found device /dev/ttyS0.
[   30.395270] zram0: detected capacity change from 0 to 111149056
[   30.517389] cv180x_thermal: bad vermagic: kernel tainted.
[   30.577356] Disabling lock debugging due to kernel taint
[   30.641455] cv180x_thermal: Unknown relocation type 57
[  OK  ] Finished Create Volatile Files and Directories.
[  OK  ] Finished Create swap on /dev/zram0.
[  OK  ] Reached target Sound Card.
[  OK  ] Listening on Load/Save RF Kill Switch Status /dev/rfkill Watch.
         Activating swap Compressed Swap on /dev/zram0...
         Starting Rebuild Journal Catalog...
         Starting Network Time Synchronization...
         Starting Record System Boot/Shutdown in UTMP...
[   32.347804] Adding 108540k swap on /dev/zram0.  Priority:100 extents:1 across:108540k SSDsc
[  OK  ] Activated swap Compressed Swap on /dev/zram0.
[  OK  ] Reached target Swaps.
[  OK  ] Finished Record System Boot/Shutdown in UTMP.
[  OK  ] Finished Rebuild Journal Catalog.
         Starting Update is Completed...
[  OK  ] Finished Update is Completed.
[  OK  ] Started Network Time Synchronization.
[  OK  ] Reached target System Initialization.
[  OK  ] Started logrotate.timer.
[  OK  ] Started Daily Cleanup of Temporary Directories.
[  OK  ] Reached target Timer Units.
[  OK  ] Listening on D-Bus System Message Bus Socket.
[  OK  ] Reached target Socket Units.
[  OK  ] Reached target Basic System.
         Starting Logrotate configuration check...
[  OK  ] Started Reset console on configuration changes.
         Starting resolvconf update...
         Starting User Login Management...
         Starting D-Bus System Message Bus...
[  OK  ] Finished Logrotate configuration check.
[  OK  ] Started D-Bus System Message Bus.
[  OK  ] Finished resolvconf update.
[  OK  ] Reached target Preparation for Network.
         Starting Networking Setup...
[  OK  ] Started User Login Management.
[  OK  ] Finished Networking Setup.
         Starting Extra networking commands....
[  OK  ] Finished Extra networking commands..
[  OK  ] Reached target Network.
[  OK  ] Reached target Network is Online.
         Starting Permit User Sessions...
[  OK  ] Finished Permit User Sessions.
[  OK  ] Started Serial Getty on ttyS0.
[  OK  ] Reached target Login Prompts.
[  OK  ] Reached target Multi-User System.


<<< Welcome to NixOS 24.05.20240206.74f7f37 (riscv64) - ttyS0 >>>

Run 'nixos-help' for the NixOS manual.

nixos login: root (automatic login)


[0;root@nixos: ~root@nixos:~]# free -h
               total        used        free      shared  buff/cache   available
Mem:            53Mi        18Mi       1.0Mi       0.0Ki        33Mi        30Mi
Swap:          105Mi       8.0Mi        97Mi

[0;root@nixos: ~root@nixos:~]# 
```