### PR TITLE
Work around randomization of host MAC

### DIFF
--- a/duo-256.nix
+++ b/duo-256.nix
@@ -231,7 +231,7 @@ in
     enable = true;
     settings = {
       interface = "usb0";
-      dhcp-range = [ "192.168.42.2,192.168.42.2,1h"];
+      dhcp-range = [ "192.168.42.2,192.168.42.254,1h"];
       dhcp-option = [ "3" "6" ];
     };
   };


### PR DESCRIPTION
RNDIS creates a virtual interface on the machine you've got your Duo plugged in to (your desktop machine).  It randomizes the MAC address of that interface on every recreation of the interface (every time the Duo board is booted). Having dnsmasq-DHCP hand out a single IP causes the DHCP client (your desktop) to fail to obtain an IP address on second and subsequent boots because it remembers the first randomized MAC of the desktop as tied to that IP.

Work around this by allowing dnsmasq to hand out more than a single IP address.  This is at best a hack, but it's also what the vendor buildroot image does and I don't yet have the foo to figure out how to unrandomize the MAC of the desktop machine declaratively.

See also:

- https://xyzdims.com/3d-printers/misc-hardware-notes/iot-milk-v-duo-risc-v-esbc-running-linux/#Static_IP_for_Host_with_RNDIS
- https://support.criticallink.com/redmine/projects/mityarm-5cs/wiki/Hard_setting_RNDIS_MAC_address