### PR TITLE
Fix build on Duo/Duo256M

### DIFF
--- a/duo-256.nix
+++ b/duo-256.nix
@@ -61,6 +61,8 @@ let
                   'KBUILD_CFLAGS += -march=$(riscv-march-cflags-y)_zicsr_zifencei' \
         --replace 'KBUILD_AFLAGS += -march=$(riscv-march-aflags-y)' \
                   'KBUILD_AFLAGS += -march=$(riscv-march-aflags-y)_zicsr_zifencei'
+      substituteInPlace arch/riscv/mm/context.c \
+        --replace sptbr CSR_SATP
     '';
   };
 in

--- a/duo-256.nix
+++ b/duo-256.nix
@@ -79,6 +79,9 @@ in
   nixpkgs = {
     localSystem.config = "x86_64-unknown-linux-gnu";
     crossSystem.config = "riscv64-unknown-linux-gnu";
+    overlays = [(final: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // {allowMissing = true;});
+    })];
   };
 
   boot.kernelPackages = pkgs.linuxPackagesFor kernel;

--- a/duo.nix
+++ b/duo.nix
@@ -69,6 +69,9 @@ in
   nixpkgs = {
     localSystem.config = "x86_64-unknown-linux-gnu";
     crossSystem.config = "riscv64-unknown-linux-gnu";
+    overlays = [(final: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // {allowMissing = true;});
+    })];
   };
 
   boot.kernelPackages = pkgs.linuxPackagesFor kernel;


### PR DESCRIPTION
- fix `sptbr/CSR_SATP` issue on Duo 256M
- fix `nixpkgs` overlay to accommodate a known issue with building kernel modules (https://github.com/NixOS/nixpkgs/issues/126755#issuecomment-869149243)